### PR TITLE
Add French GGWave locale

### DIFF
--- a/locale/fr-fr/disable.ggwave.intent
+++ b/locale/fr-fr/disable.ggwave.intent
@@ -1,0 +1,2 @@
+(désactive|arrête|coupe) (ggwave|code audio|codes audio|code qr audio|codes qr audio|données audio)
+(ggwave|code audio|codes audio|code qr audio|codes qr audio|données audio) désactivé

--- a/locale/fr-fr/enable.ggwave.intent
+++ b/locale/fr-fr/enable.ggwave.intent
@@ -1,0 +1,2 @@
+(active|démarre|autorise) (ggwave|code audio|codes audio|code qr audio|codes qr audio|données audio)
+(ggwave|code audio|codes audio|code qr audio|codes qr audio|données audio) activé

--- a/locale/fr-fr/ggwave.already.disabled.dialog
+++ b/locale/fr-fr/ggwave.already.disabled.dialog
@@ -1,0 +1,1 @@
+Les codes QR audio sont déjà désactivés.

--- a/locale/fr-fr/ggwave.already.enabled.dialog
+++ b/locale/fr-fr/ggwave.already.enabled.dialog
@@ -1,0 +1,1 @@
+Les codes QR audio sont déjà activés.

--- a/locale/fr-fr/ggwave.disabled.dialog
+++ b/locale/fr-fr/ggwave.disabled.dialog
@@ -1,0 +1,1 @@
+Je désactive les codes QR audio.

--- a/locale/fr-fr/ggwave.enabled.dialog
+++ b/locale/fr-fr/ggwave.enabled.dialog
@@ -1,0 +1,1 @@
+J'active les codes QR audio pendant 15 minutes.

--- a/locale/fr-fr/ggwave.entity
+++ b/locale/fr-fr/ggwave.entity
@@ -1,0 +1,4 @@
+ggwave
+(code|codes) audio
+données audio
+(code|codes) qr audio

--- a/locale/fr-fr/skill.json
+++ b/locale/fr-fr/skill.json
@@ -5,12 +5,12 @@
   "extra_plugins": {
     "listener": ["ovos-audio-transformer-plugin-ggwave"]
   },
-  "name": "Skill GGWave",
-  "description": "Interface vocale pour le plugin ggwave.",
+  "name": "GGWave",
+  "description": "Permet d'échanger des données audio avec ggwave.",
   "examples": [
     "Démarre ggwave",
     "Autorise les données audio",
     "Désactive les codes audio"
   ],
-  "tags": ["interface vocale", "plugin audio", "ggwave"]
+  "tags": ["interface vocale", "audio", "ggwave"]
 }

--- a/locale/fr-fr/skill.json
+++ b/locale/fr-fr/skill.json
@@ -1,0 +1,16 @@
+{
+  "skill_id": "ovos-skill-ggwave.openvoiceos",
+  "source": "https://github.com/OpenVoiceOS/ovos-skill-ggwave",
+  "package_name": "ovos-skill-ggwave",
+  "extra_plugins": {
+    "listener": ["ovos-audio-transformer-plugin-ggwave"]
+  },
+  "name": "Skill GGWave",
+  "description": "Interface vocale pour le plugin ggwave.",
+  "examples": [
+    "Démarre ggwave",
+    "Autorise les données audio",
+    "Désactive les codes audio"
+  ],
+  "tags": ["interface vocale", "plugin audio", "ggwave"]
+}


### PR DESCRIPTION
## Summary
- add a complete French locale tree for GGWave dialogs, intents, entity patterns, and metadata
- keep the phrasing aligned with the existing audio-code voice commands

## Validation
- verified fr-fr file coverage against locale/en-us
- validated locale/fr-fr/skill.json parses as JSON