### PR TITLE
fix: use canonical opm.* entry-point group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,5 +42,5 @@ ovos_skill_ggwave = [
     "locale/*/*.json",
 ]
 
-[project.entry-points."ovos.plugin.skill"]
+[project.entry-points."opm.skill"]
 "ovos-skill-ggwave.openvoiceos" = "ovos_skill_ggwave:GGWaveSkill"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ authors = [
 ]
 requires-python = ">=3.10"
 dependencies = [
+    "ovos-plugin-manager>=2.4.0a1",
     "ovos-workshop>=0.0.15",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Modernize the plugin's entry-point group from the deprecated `ovos.plugin.skill` to the canonical `opm.skill` (PluginTypes value in ovos-plugin-manager). The loader aliases the old name, but the canonical group is the current standard.