### PR TITLE
fix: require ovos-plugin-manager>=2.1.0 for opm.* entry points and cap ovos-* deps at next major

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -11,5 +11,6 @@ jobs:
     secrets: inherit
     with:
       python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+      system_deps: 'swig libfann-dev'
       install_extras: 'test'
       test_path: 'test'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,5 +13,6 @@ jobs:
       python_version: '3.11'
       coverage_source: 'ovos_skill_ggwave'
       test_path: 'test/'
-      install_extras: ''
+      system_deps: 'swig libfann-dev'
+      test_extras: 'test'
       min_coverage: 0

--- a/.github/workflows/ovoscope.yml
+++ b/.github/workflows/ovoscope.yml
@@ -12,4 +12,5 @@ jobs:
     with:
       python_version: '3.11'
       install_extras: 'test'
+      require_padatious: true
       test_path: 'test/end2end/'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,14 +12,14 @@ authors = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "ovos-plugin-manager>=2.4.0a1",
-    "ovos-workshop>=0.0.15",
+    "ovos-plugin-manager>=2.1.0,<3.0.0",
+    "ovos-workshop>=0.0.15,<9.0.0",
 ]
 dynamic = ["version"]
 
 [project.optional-dependencies]
 test = [
-    "ovoscope>=0.12.0",
+    "ovoscope>=0.12.0,<1.0.0",
     "ovos-padatious",
     "ovos-adapt-parser",
 ]


### PR DESCRIPTION
The `opm.*` entry-point group(s) declared by this package are only recognized by `ovos-plugin-manager>=2.1.0` (canonical in PluginTypes since 2.1.0; `opm.agents.*` since 2.3.0a1). An older plugin-manager queries the legacy entry-point group and silently never discovers the plugin. Also caps all `ovos-*` dependencies at the next major so the latest published versions resolve.