### PR TITLE
fix(da-DK): restructure ggwave trigger words as an entity file

### DIFF
--- a/ovos_skill_ggwave/locale/da-DK/disable_ggwave.intent
+++ b/ovos_skill_ggwave/locale/da-DK/disable_ggwave.intent
@@ -1,2 +1,2 @@
-(deaktiver|stop|disallow|lukning) (ggwave|lydkode|lydkoder|lyd-qr-kode|lyd-qr-koder|lyddata)
-(ggwave|lydkode|lydkoder|lyd-qr-kode|lyd-qr-koder|lyddata) fra
+(deaktiver|stop|afvis|luk ned) {ggwave}
+{ggwave} fra

--- a/ovos_skill_ggwave/locale/da-DK/enable_ggwave.intent
+++ b/ovos_skill_ggwave/locale/da-DK/enable_ggwave.intent
@@ -1,2 +1,2 @@
-(aktiver|start|tillad) (ggwave|lydkode|lydkoder|lyd-qr-kode|lyd-qr-koder|lyddata)
-(ggwave|lydkode|lydkoder|lyd-qr-kode|lyd-qr-koder|lyddata) på
+(aktiver|start|tillad) {ggwave}
+{ggwave} (til|aktiveret)

--- a/ovos_skill_ggwave/locale/da-DK/ggwave.entity
+++ b/ovos_skill_ggwave/locale/da-DK/ggwave.entity
@@ -1,0 +1,4 @@
+ggwave
+lyd(kode|koder)
+lyd-qr-(kode|koder)
+lyddata


### PR DESCRIPTION
The da-DK intents inlined the ggwave/audio-code synonyms directly as a literal alternation group instead of referencing a `{ggwave}` entity, unlike en-US and fr-FR which both use a dedicated `ggwave.entity` file.

Not a functional break - I checked, the handler does not consume the matched slot value, it just needs the phrase to match - but inconsistent with the established pattern and flagged by ovos-localize as a missing `{ggwave}` slot.

Added `locale/da-DK/ggwave.entity` with the same Danish terms that were previously inlined, and updated both intents to reference `{ggwave}` instead, matching the en-US/fr-FR structure.

Found while doing a general da-DK translation review.